### PR TITLE
fix: Incorrect text position when dragging under zoom or scale

### DIFF
--- a/app/components/editor/player/remotion/sequence/items/text-sequence-item.tsx
+++ b/app/components/editor/player/remotion/sequence/items/text-sequence-item.tsx
@@ -41,15 +41,22 @@ export const TextSequenceItem: React.FC<{ item: TextElement; options: SequenceIt
         )));
     };
 
+    // TODO: Extract this logic to be reusable for other draggable items
     const handleMouseDown = (e: React.MouseEvent) => {
         e.preventDefault();
-        const startX = e.clientX - item.x;
-        const startY = e.clientY - item.y;
+        const startX = e.clientX;
+        const startY = e.clientY;
+
+        // TODO: This needs a more reliable way to get the scaled container
+        const container = document.querySelector('.__remotion-player') as HTMLElement; 
+        const rect = container.getBoundingClientRect();
+        const scaleX = rect.width / container.offsetWidth;
+        const scaleY = rect.height / container.offsetHeight;
 
         const handleMouseMove = (e: MouseEvent) => {
-            const newX = e.clientX - startX;
-            const newY = e.clientY - startY;
-            onUpdateText(item.id, { x: newX, y: newY});
+            const diffX = e.clientX - startX;
+            const diffY = e.clientY - startY;
+            onUpdateText(item.id, { x: item.x + diffX / scaleX, y: item.y + diffY / scaleY});
             
             // handleTextChange fonksiyonu varsa pozisyon güncellemesini bildir
             if (handleTextChange) {


### PR DESCRIPTION
## Bug Description
Dragging text or rectangle elements inside the editor results in incorrect positioning when the browser zoom level changes or when the preview container (e.g., .__remotion-player) is visually scaled using CSS transforms.
The drag offset is calculated using raw clientX/clientY values, which do not account for visual scaling or device pixel ratio differences.

## Steps to Reproduce
- Open the editor and load a project.
- Add a Text to the Player.
- Zoom the browser in or out (e.g., 125%).
- Try to drag a text element to a new position.
- Observe that the element moves too far or too little compared to the cursor movement.

## Expected Behavior
- The dragged element should follow the cursor precisely, regardless of browser zoom level or container scaling.